### PR TITLE
Replace lager 2.0.1 within error_logger

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,18 +13,7 @@
     strict_validation,
     warn_export_vars,
     warn_exported_vars,
-    warn_untyped_record,
-
-    {parse_transform, lager_transform},
-    {lager_truncation_size, 4096}
-]}.
-
-{deps_dir, "deps"}.
-
-{deps, [
-    {lager, "2.0.1",
-        {git, "git://github.com/basho/lager.git",
-            {tag, "2.0.1"}}}
+    warn_untyped_record
 ]}.
 
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.

--- a/src/corman.erl
+++ b/src/corman.erl
@@ -87,7 +87,8 @@ parse_config(File) ->
 reload_ll(Applications, Config, AppsToRestart) ->
     case application_specs(Applications) of
         {incorrect_specs, IncorrectApps} ->
-            lager:error("Unable to reload applications configs.~n The following applications have incorrect specifications ~p", [IncorrectApps]),
+            error_logger:error_msg("Unable to reload applications configs.~n "
+                                   "The following applications have incorrect specifications ~p", [IncorrectApps]),
             {error, {incorrect_specs, IncorrectApps}};
         Specs ->
             {change_application_data(Specs, Config, AppsToRestart), Applications}
@@ -119,7 +120,7 @@ parse_app_file(AppSpecPath) ->
 
 
 change_application_data(Specs, Config, AppsToRestart) ->
-    lager:info("Update configurations for the following applications: ~p", [[App || {_, App, _} <- Specs]]),
+    error_logger:info_msg("Update configurations for the following applications: ~p", [[App || {_, App, _} <- Specs]]),
     % Fetch OLD applications' environment from
     % application controller's internal ETS table.
     OldEnv = application_controller:prep_config_change(),


### PR DESCRIPTION
to make corman different projects compatible regardless of logger library
and its version

All related pull requests ask to update lager dependency to lager 2.1.0, but it is not a solution,
because there are a lot of projects that uses variety of lager versions.

Therefore 2 possible solutions exist: 
- link project to any lager version ".*"
- or use lager error_logger_redirect feature

Last one is probably the best, because reduce dependencies number to zero and thus make 
library more flexible.
